### PR TITLE
Add new datatypes

### DIFF
--- a/datatypes/objectid.go
+++ b/datatypes/objectid.go
@@ -39,9 +39,9 @@ func NewObjectId() ObjectId {
 	return newObjectId(time.Now())
 }
 
-// NewObjectIdFromTimestamp generates a new ObjectId encoding the given timestamp.
+// NewObjectIdAt generates a new ObjectId encoding the given timestamp.
 // The random and counter components are still generated normally.
-func NewObjectIdFromTimestamp(t time.Time) ObjectId {
+func NewObjectIdAt(t time.Time) ObjectId {
 	return newObjectId(t)
 }
 

--- a/datatypes/objectid.go
+++ b/datatypes/objectid.go
@@ -1,0 +1,145 @@
+package datatypes
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ObjectId represents an ObjectId that can be used as an _id in the DataAPI.
+// json.Marshals to {"$objectId": "6672e1cbd7fabb4e5493916f"}.
+type ObjectId struct {
+	// An ObjectId is 12 bytes: 4 bytes timestamp (seconds) + 5 bytes random + 3 bytes counter.
+	value [12]byte
+}
+
+var (
+	oidOnce    sync.Once
+	oidRandID  [5]byte // 3 bytes machine ID + 2 bytes PID-like
+	oidCounter uint32
+)
+
+func initOid() {
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		// See note in DataAPIVector but this PROBABLY can never happen. But just in case...
+		panic(fmt.Sprintf("datatypes: crypto/rand failed: %v", err))
+	}
+	copy(oidRandID[:], buf[:5])
+	// Initialize counter to a random 24-bit value.
+	oidCounter = uint32(buf[5])<<16 | uint32(buf[6])<<8 | uint32(buf[7])
+}
+
+// NewObjectId generates a new ObjectId based on the current time.
+func NewObjectId() ObjectId {
+	return newObjectId(time.Now())
+}
+
+// NewObjectIdFromTimestamp generates a new ObjectId encoding the given timestamp.
+// The random and counter components are still generated normally.
+func NewObjectIdFromTimestamp(t time.Time) ObjectId {
+	return newObjectId(t)
+}
+
+func newObjectId(t time.Time) ObjectId {
+	oidOnce.Do(initOid)
+
+	var o ObjectId
+	// Bytes 0–3: Unix timestamp in seconds (big-endian).
+	ts := uint32(t.Unix())
+	o.value[0] = byte(ts >> 24)
+	o.value[1] = byte(ts >> 16)
+	o.value[2] = byte(ts >> 8)
+	o.value[3] = byte(ts)
+	// Bytes 4–8: random machine ID + PID-like value (set once per process).
+	copy(o.value[4:9], oidRandID[:])
+	// Bytes 9–11: auto-incrementing 24-bit counter.
+	c := atomic.AddUint32(&oidCounter, 1) % 0x1000000
+	o.value[9] = byte(c >> 16)
+	o.value[10] = byte(c >> 8)
+	o.value[11] = byte(c)
+
+	return o
+}
+
+// ParseObjectId parses an ObjectId from its 24-character hex string representation.
+func ParseObjectId(s string) (ObjectId, error) {
+	if len(s) != 24 {
+		return ObjectId{}, fmt.Errorf("datatypes: invalid ObjectId string: %q (expected 24 hex characters)", s)
+	}
+	var o ObjectId
+	if _, err := hex.Decode(o.value[:], []byte(s)); err != nil {
+		return ObjectId{}, fmt.Errorf("datatypes: invalid ObjectId string: %q: %w", s, err)
+	}
+	return o, nil
+}
+
+// String returns the 24-character lowercase hex representation of the ObjectId.
+func (o ObjectId) String() string {
+	return hex.EncodeToString(o.value[:])
+}
+
+// GetTimestamp extracts the creation timestamp from the ObjectId.
+// The first 4 bytes encode Unix seconds.
+func (o ObjectId) GetTimestamp() time.Time {
+	secs := int64(o.value[0])<<24 | int64(o.value[1])<<16 | int64(o.value[2])<<8 | int64(o.value[3])
+	return time.Unix(secs, 0)
+}
+
+// IsZero returns true if the ObjectId is the zero value (all bytes are 0).
+func (o ObjectId) IsZero() bool {
+	return o.value == [12]byte{}
+}
+
+// Equals returns true if the two ObjectIds have identical bytes.
+func (o ObjectId) Equals(other ObjectId) bool {
+	return o.value == other.value
+}
+
+// Bytes returns the raw 12-byte ObjectId value.
+func (o ObjectId) Bytes() [12]byte {
+	return o.value
+}
+
+// MarshalJSON produces the Data API extended JSON format: {"$objectId": "6672e1cbd7fabb4e5493916f"}.
+func (o ObjectId) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]string{"$objectId": o.String()})
+}
+
+// UnmarshalJSON parses the Data API extended JSON format: {"$objectId": "..."}.
+func (o *ObjectId) UnmarshalJSON(data []byte) error {
+	var wrapper map[string]string
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return fmt.Errorf("datatypes: invalid ObjectId JSON: %w", err)
+	}
+	s, ok := wrapper["$objectId"]
+	if !ok {
+		return fmt.Errorf("datatypes: missing $objectId key in JSON")
+	}
+	parsed, err := ParseObjectId(s)
+	if err != nil {
+		return err
+	}
+	*o = parsed
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler. It returns the 24-character
+// lowercase hex string.
+func (o ObjectId) MarshalText() ([]byte, error) {
+	return []byte(o.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler. It parses a 24-character hex string.
+func (o *ObjectId) UnmarshalText(data []byte) error {
+	parsed, err := ParseObjectId(string(data))
+	if err != nil {
+		return err
+	}
+	*o = parsed
+	return nil
+}

--- a/datatypes/objectid_test.go
+++ b/datatypes/objectid_test.go
@@ -77,8 +77,6 @@ func TestObjectIdInsertManyExample(t *testing.T) {
 }
 
 // TestObjectIdParseAndString verifies parse/string round-trip.
-//
-// Doc reference: https://docs.datastax.com/en/astra-db-serverless/api-reference/document-id.html
 func TestObjectIdParseAndString(t *testing.T) {
 	hex := "6672e1cbd7fabb4e5493916f"
 	oid, err := ParseObjectId(hex)
@@ -224,8 +222,6 @@ func TestObjectIdTextRoundTrip(t *testing.T) {
 
 // TestObjectIdKnownTimestamp verifies that parsing a known ObjectId from the docs
 // extracts the expected timestamp.
-//
-// Doc reference: https://docs.datastax.com/en/astra-db-serverless/api-reference/document-id.html
 func TestObjectIdKnownTimestamp(t *testing.T) {
 	// "6672e1cb" = first 4 bytes = 0x6672e1cb = 1718812107 seconds
 	// = 2024-06-19T14:28:27 UTC

--- a/datatypes/objectid_test.go
+++ b/datatypes/objectid_test.go
@@ -1,0 +1,264 @@
+package datatypes
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestObjectIdJSONMarshalInDocument verifies ObjectId serialization within a document struct,
+// matching the Data API insertMany format.
+//
+// From the docs, an insertMany payload with an ObjectId _id looks like:
+//
+//	{
+//	  "insertMany": {
+//	    "documents": [
+//	      {
+//	        "name": "Melissa",
+//	        "_id": {"$objectId": "6672e1cbd7fabb4e5493916f"}
+//	      }
+//	    ]
+//	  }
+//	}
+//
+// Doc reference: https://docs.datastax.com/en/astra-db-serverless/api-reference/document-id.html
+func TestObjectIdJSONMarshalInDocument(t *testing.T) {
+	type doc struct {
+		ID   ObjectId `json:"_id"`
+		Name string   `json:"name"`
+	}
+	oid, _ := ParseObjectId("6672e1cbd7fabb4e5493916f")
+	d := doc{ID: oid, Name: "Melissa"}
+	got, err := json.Marshal(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `{"_id":{"$objectId":"6672e1cbd7fabb4e5493916f"},"name":"Melissa"}`
+	if string(got) != expected {
+		t.Errorf("document marshal mismatch\n  got:  %s\n  want: %s", string(got), expected)
+	}
+
+	// Round-trip
+	var decoded doc
+	if err := json.Unmarshal(got, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if !decoded.ID.Equals(oid) {
+		t.Errorf("round-trip ID mismatch: %s != %s", decoded.ID, oid)
+	}
+}
+
+// TestObjectIdInsertManyExample verifies that a mixed-ID insertMany payload can
+// be marshaled and unmarshaled, matching the docs example.
+//
+// Doc reference: https://docs.datastax.com/en/astra-db-serverless/api-reference/document-id.html
+func TestObjectIdInsertManyExample(t *testing.T) {
+	type doc struct {
+		Name string `json:"name"`
+		ID   any    `json:"_id"`
+	}
+	oid, _ := ParseObjectId("6672e1cbd7fabb4e5493916f")
+	uid, _ := ParseUUID("1ef2e42c-1fdb-6ad6-aae4-e84679831739")
+
+	// Marshal the ObjectId document
+	d := struct {
+		Name string   `json:"name"`
+		ID   ObjectId `json:"_id"`
+	}{Name: "Melissa", ID: oid}
+	got, err := json.Marshal(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `{"name":"Melissa","_id":{"$objectId":"6672e1cbd7fabb4e5493916f"}}`
+	if string(got) != expected {
+		t.Errorf("ObjectId doc mismatch\n  got:  %s\n  want: %s", string(got), expected)
+	}
+
+	// Marshal the UUID document
+	d2 := struct {
+		Name string `json:"name"`
+		ID   UUID   `json:"_id"`
+	}{Name: "Jess", ID: uid}
+	got2, err := json.Marshal(d2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected2 := `{"name":"Jess","_id":{"$uuid":"1ef2e42c-1fdb-6ad6-aae4-e84679831739"}}`
+	if string(got2) != expected2 {
+		t.Errorf("UUID doc mismatch\n  got:  %s\n  want: %s", string(got2), expected2)
+	}
+}
+
+// TestObjectIdParseAndString verifies parse/string round-trip.
+//
+// Doc reference: https://docs.datastax.com/en/astra-db-serverless/api-reference/document-id.html
+func TestObjectIdParseAndString(t *testing.T) {
+	hex := "6672e1cbd7fabb4e5493916f"
+	oid, err := ParseObjectId(hex)
+	if err != nil {
+		t.Fatalf("ParseObjectId(%q) error: %v", hex, err)
+	}
+	if oid.String() != hex {
+		t.Errorf("String() = %q, want %q", oid.String(), hex)
+	}
+	// Verify round-trip
+	oid2, err := ParseObjectId(oid.String())
+	if err != nil {
+		t.Fatalf("round-trip parse error: %v", err)
+	}
+	if !oid.Equals(oid2) {
+		t.Errorf("round-trip mismatch: %s != %s", oid, oid2)
+	}
+}
+
+// TestObjectIdInvalidParsing tests that invalid strings return errors.
+func TestObjectIdInvalidParsing(t *testing.T) {
+	invalid := []string{
+		"",                          // empty
+		"6672e1cbd7fabb4e549391",    // too short (22 chars)
+		"6672e1cbd7fabb4e549391600", // too long (25 chars)
+		"6672e1cbd7fabb4e5493916Z",  // invalid hex character
+		"not-a-valid-object-id!!!",  // completely wrong
+	}
+	for _, s := range invalid {
+		if _, err := ParseObjectId(s); err == nil {
+			t.Errorf("expected error for invalid ObjectId %q, got nil", s)
+		}
+	}
+}
+
+// TestObjectIdJSONUnmarshalInvalid verifies error handling for invalid JSON inputs.
+func TestObjectIdJSONUnmarshalInvalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"not an object", `"not-an-object"`},
+		{"missing $objectId key", `{"objectId":"6672e1cbd7fabb4e5493916f"}`},
+		{"invalid objectId value", `{"$objectId":"not-valid"}`},
+		{"empty object", `{}`},
+		{"too short", `{"$objectId":"6672e1"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var o ObjectId
+			if err := json.Unmarshal([]byte(tt.input), &o); err == nil {
+				t.Error("expected error but got none")
+			}
+		})
+	}
+}
+
+// TestObjectIdGeneration verifies NewObjectId produces valid, unique ObjectIds.
+func TestObjectIdGeneration(t *testing.T) {
+	o1 := NewObjectId()
+	o2 := NewObjectId()
+
+	if o1.IsZero() {
+		t.Error("expected non-zero ObjectId")
+	}
+	if o1.Equals(o2) {
+		t.Errorf("expected unique ObjectIds, got identical: %s", o1)
+	}
+	// String should be 24 hex chars
+	if len(o1.String()) != 24 {
+		t.Errorf("expected 24-char hex string, got %d chars: %s", len(o1.String()), o1)
+	}
+}
+
+// TestObjectIdGetTimestamp verifies timestamp extraction from generated ObjectIds.
+func TestObjectIdGetTimestamp(t *testing.T) {
+	now := time.Now()
+	o := NewObjectId()
+	ts := o.GetTimestamp()
+	diff := ts.Sub(now)
+	if diff < 0 {
+		diff = -diff
+	}
+	// Timestamps have second precision, so 2s tolerance is generous.
+	if diff > 2*time.Second {
+		t.Errorf("timestamp %v differs from now %v by %v", ts, now, diff)
+	}
+}
+
+// TestObjectIdFromTimestamp verifies NewObjectIdFromTimestamp encodes the given time.
+func TestObjectIdFromTimestamp(t *testing.T) {
+	target := time.Date(2024, 6, 19, 10, 0, 0, 0, time.UTC)
+	o := NewObjectIdFromTimestamp(target)
+
+	ts := o.GetTimestamp()
+	if ts.Unix() != target.Unix() {
+		t.Errorf("timestamp mismatch: got %v (%d), want %v (%d)",
+			ts, ts.Unix(), target, target.Unix())
+	}
+}
+
+// TestObjectIdFromTimestampUniqueness verifies two ObjectIds at the same time differ.
+func TestObjectIdFromTimestampUniqueness(t *testing.T) {
+	target := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	o1 := NewObjectIdFromTimestamp(target)
+	o2 := NewObjectIdFromTimestamp(target)
+	if o1.Equals(o2) {
+		t.Errorf("expected unique ObjectIds at same timestamp, got identical: %s", o1)
+	}
+	// Both should encode the same timestamp
+	if o1.GetTimestamp().Unix() != o2.GetTimestamp().Unix() {
+		t.Errorf("expected same timestamp, got %v and %v", o1.GetTimestamp(), o2.GetTimestamp())
+	}
+}
+
+// TestObjectIdIsZero verifies IsZero behavior.
+func TestObjectIdIsZero(t *testing.T) {
+	var zero ObjectId
+	if !zero.IsZero() {
+		t.Error("expected zero ObjectId to be zero")
+	}
+	o := NewObjectId()
+	if o.IsZero() {
+		t.Error("expected generated ObjectId to be non-zero")
+	}
+}
+
+// TestObjectIdTextRoundTrip verifies MarshalText/UnmarshalText round-trip.
+func TestObjectIdTextRoundTrip(t *testing.T) {
+	o := NewObjectId()
+	text, err := o.MarshalText()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed ObjectId
+	if err := parsed.UnmarshalText(text); err != nil {
+		t.Fatalf("UnmarshalText error: %v", err)
+	}
+	if !o.Equals(parsed) {
+		t.Errorf("text round-trip mismatch: %s != %s", o, parsed)
+	}
+}
+
+// TestObjectIdKnownTimestamp verifies that parsing a known ObjectId from the docs
+// extracts the expected timestamp.
+//
+// Doc reference: https://docs.datastax.com/en/astra-db-serverless/api-reference/document-id.html
+func TestObjectIdKnownTimestamp(t *testing.T) {
+	// "6672e1cb" = first 4 bytes = 0x6672e1cb = 1718812107 seconds
+	// = 2024-06-19T14:28:27 UTC
+	oid, err := ParseObjectId("6672e1cbd7fabb4e5493916f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := oid.GetTimestamp()
+	expected := time.Unix(0x6672e1cb, 0)
+	if ts.Unix() != expected.Unix() {
+		t.Errorf("timestamp = %v, want %v", ts, expected)
+	}
+}
+
+func TestObjectId_EqualsCaseInsensitive(t *testing.T) {
+	// Taken from 'should equal a similar ObjectId' test in ts
+	oid, _ := ParseObjectId("507f191e810c19729de860ea")
+	other, _ := ParseObjectId("507F191E810C19729DE860EA")
+	if !oid.Equals(other) {
+		t.Errorf("%s should equal %s", oid, other)
+	}
+}

--- a/datatypes/objectid_test.go
+++ b/datatypes/objectid_test.go
@@ -166,10 +166,10 @@ func TestObjectIdGetTimestamp(t *testing.T) {
 	}
 }
 
-// TestObjectIdFromTimestamp verifies NewObjectIdFromTimestamp encodes the given time.
+// TestObjectIdFromTimestamp verifies NewObjectIdAt encodes the given time.
 func TestObjectIdFromTimestamp(t *testing.T) {
 	target := time.Date(2024, 6, 19, 10, 0, 0, 0, time.UTC)
-	o := NewObjectIdFromTimestamp(target)
+	o := NewObjectIdAt(target)
 
 	ts := o.GetTimestamp()
 	if ts.Unix() != target.Unix() {
@@ -181,8 +181,8 @@ func TestObjectIdFromTimestamp(t *testing.T) {
 // TestObjectIdFromTimestampUniqueness verifies two ObjectIds at the same time differ.
 func TestObjectIdFromTimestampUniqueness(t *testing.T) {
 	target := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	o1 := NewObjectIdFromTimestamp(target)
-	o2 := NewObjectIdFromTimestamp(target)
+	o1 := NewObjectIdAt(target)
+	o2 := NewObjectIdAt(target)
 	if o1.Equals(o2) {
 		t.Errorf("expected unique ObjectIds at same timestamp, got identical: %s", o1)
 	}

--- a/datatypes/objectid_test.go
+++ b/datatypes/objectid_test.go
@@ -52,41 +52,27 @@ func TestObjectIdJSONMarshalInDocument(t *testing.T) {
 // TestObjectIdInsertManyExample verifies that a mixed-ID insertMany payload can
 // be marshaled and unmarshaled, matching the docs example.
 //
-// Doc reference: https://docs.datastax.com/en/astra-db-serverless/api-reference/document-id.html
+// Doc reference: https://docs.datastax.com/en/astra-db-serverless/api-reference/document-methods/insert-many.html#example-specify-id
 func TestObjectIdInsertManyExample(t *testing.T) {
 	type doc struct {
-		Name string `json:"name"`
 		ID   any    `json:"_id"`
-	}
-	oid, _ := ParseObjectId("6672e1cbd7fabb4e5493916f")
-	uid, _ := ParseUUID("1ef2e42c-1fdb-6ad6-aae4-e84679831739")
-
-	// Marshal the ObjectId document
-	d := struct {
-		Name string   `json:"name"`
-		ID   ObjectId `json:"_id"`
-	}{Name: "Melissa", ID: oid}
-	got, err := json.Marshal(d)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := `{"name":"Melissa","_id":{"$objectId":"6672e1cbd7fabb4e5493916f"}}`
-	if string(got) != expected {
-		t.Errorf("ObjectId doc mismatch\n  got:  %s\n  want: %s", string(got), expected)
-	}
-
-	// Marshal the UUID document
-	d2 := struct {
 		Name string `json:"name"`
-		ID   UUID   `json:"_id"`
-	}{Name: "Jess", ID: uid}
-	got2, err := json.Marshal(d2)
+	}
+	melissaOid, _ := ParseObjectId("6672e1cbd7fabb4e5493916f")
+	jessUid, _ := ParseUUID("1ef2e42c-1fdb-6ad6-aae4-e84679831739")
+	docs := []doc{
+		{Name: "Melissa", ID: melissaOid},
+		{Name: "Jess", ID: jessUid},
+		{Name: "Jane", ID: 1},
+		{Name: "Bobby", ID: "b_023"},
+	}
+	got, err := json.Marshal(docs)
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected2 := `{"name":"Jess","_id":{"$uuid":"1ef2e42c-1fdb-6ad6-aae4-e84679831739"}}`
-	if string(got2) != expected2 {
-		t.Errorf("UUID doc mismatch\n  got:  %s\n  want: %s", string(got2), expected2)
+	expected := `[{"_id":{"$objectId":"6672e1cbd7fabb4e5493916f"},"name":"Melissa"},{"_id":{"$uuid":"1ef2e42c-1fdb-6ad6-aae4-e84679831739"},"name":"Jess"},{"_id":1,"name":"Jane"},{"_id":"b_023","name":"Bobby"}]`
+	if string(got) != expected {
+		t.Errorf("\nGOT:\n%s\nWANT:\n%s", string(got), expected)
 	}
 }
 

--- a/datatypes/timestamp.go
+++ b/datatypes/timestamp.go
@@ -1,0 +1,82 @@
+package datatypes
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// DataAPITimestamp represents a timestamp with Data API JSON serialization.
+// On the wire, timestamps are serialized as extended JSON: {"$date": 1690045891000}.
+// The value is Unix epoch milliseconds, matching the TypeScript client's Date.valueOf().
+type DataAPITimestamp struct {
+	value time.Time
+}
+
+// NewDataAPITimestamp creates a DataAPITimestamp from a time.Time.
+func NewDataAPITimestamp(t time.Time) DataAPITimestamp {
+	return DataAPITimestamp{value: t}
+}
+
+// DataAPITimestampNow creates a DataAPITimestamp for the current time.
+func DataAPITimestampNow() DataAPITimestamp {
+	return DataAPITimestamp{value: time.Now()}
+}
+
+// DataAPITimestampFromMillis creates a DataAPITimestamp from Unix epoch milliseconds.
+func DataAPITimestampFromMillis(ms int64) DataAPITimestamp {
+	return DataAPITimestamp{value: time.UnixMilli(ms)}
+}
+
+// Time returns the underlying time.Time value.
+func (t DataAPITimestamp) Time() time.Time {
+	return t.value
+}
+
+// UnixMillis returns the timestamp as Unix epoch milliseconds.
+func (t DataAPITimestamp) UnixMillis() int64 {
+	return t.value.UnixMilli()
+}
+
+// IsZero returns true if the timestamp is the zero value.
+func (t DataAPITimestamp) IsZero() bool {
+	return t.value.IsZero()
+}
+
+// Equals returns true if the two timestamps represent the same millisecond.
+func (t DataAPITimestamp) Equals(other DataAPITimestamp) bool {
+	return t.value.UnixMilli() == other.value.UnixMilli()
+}
+
+// String returns the timestamp in RFC 3339 format for display.
+func (t DataAPITimestamp) String() string {
+	return t.value.UTC().Format(time.RFC3339Nano)
+}
+
+// MarshalJSON produces the Data API extended JSON format: {"$date": 1690045891000}.
+func (t DataAPITimestamp) MarshalJSON() ([]byte, error) {
+	if t.value.IsZero() {
+		return []byte("null"), nil
+	}
+	// Slight optimization over json.Marshal(map[string]int64{"$date": t.value.UnixMilli()}).
+	// In practice, this probably matters little.
+	return fmt.Appendf(nil, `{"$date":%d}`, t.value.UnixMilli()), nil
+}
+
+// UnmarshalJSON parses the Data API extended JSON format: {"$date": <milliseconds>}.
+func (t *DataAPITimestamp) UnmarshalJSON(data []byte) error {
+	var wrapper map[string]json.Number
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return fmt.Errorf("datatypes: invalid $date JSON: %w", err)
+	}
+	v, ok := wrapper["$date"]
+	if !ok {
+		return fmt.Errorf("datatypes: missing $date key in JSON")
+	}
+	ms, err := v.Int64()
+	if err != nil {
+		return fmt.Errorf("datatypes: invalid $date value: %w", err)
+	}
+	t.value = time.UnixMilli(ms)
+	return nil
+}

--- a/datatypes/timestamp_test.go
+++ b/datatypes/timestamp_test.go
@@ -1,0 +1,183 @@
+package datatypes
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestDataAPITimestampJSONMarshalInDocument verifies DataAPITimestamp serialization
+// within a document struct, matching the Data API $date format.
+//
+// From the docs:
+//
+//	{"date_of_birth": {"$date": 1690045891}}
+//
+// The wire format uses milliseconds since the Unix epoch.
+//
+// Doc reference: https://docs.datastax.com/en/astra-db-serverless/api-reference/collection-dates.html
+func TestDataAPITimestampJSONMarshalInDocument(t *testing.T) {
+	type doc struct {
+		Name        string           `json:"name"`
+		DateOfBirth DataAPITimestamp `json:"date_of_birth"`
+	}
+	// 1690045891 seconds = 1690045891000 milliseconds.
+	ts := DataAPITimestampFromMillis(1690045891000)
+	d := doc{Name: "example", DateOfBirth: ts}
+	got, err := json.Marshal(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `{"name":"example","date_of_birth":{"$date":1690045891000}}`
+	if string(got) != expected {
+		t.Errorf("document marshal mismatch\n  got:  %s\n  want: %s", string(got), expected)
+	}
+
+	// Round-trip
+	var decoded doc
+	if err := json.Unmarshal(got, &decoded); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if !decoded.DateOfBirth.Equals(ts) {
+		t.Errorf("round-trip mismatch: %v != %v", decoded.DateOfBirth, ts)
+	}
+}
+
+// TestDataAPITimestampFromMillis verifies creating a timestamp from milliseconds.
+func TestDataAPITimestampFromMillis(t *testing.T) {
+	ms := int64(1690045891000) // 2023-07-22T15:31:31Z
+	ts := DataAPITimestampFromMillis(ms)
+
+	if ts.UnixMillis() != ms {
+		t.Errorf("UnixMillis() = %d, want %d", ts.UnixMillis(), ms)
+	}
+
+	expected := time.Unix(1690045891, 0).UTC()
+	if !ts.Time().Equal(expected) {
+		t.Errorf("Time() = %v, want %v", ts.Time(), expected)
+	}
+}
+
+// TestDataAPITimestampFromTime verifies creating a timestamp from time.Time.
+func TestDataAPITimestampFromTime(t *testing.T) {
+	target := time.Date(2024, 6, 15, 12, 30, 45, 0, time.UTC)
+	ts := NewDataAPITimestamp(target)
+
+	if !ts.Time().Equal(target) {
+		t.Errorf("Time() = %v, want %v", ts.Time(), target)
+	}
+	if ts.UnixMillis() != target.UnixMilli() {
+		t.Errorf("UnixMillis() = %d, want %d", ts.UnixMillis(), target.UnixMilli())
+	}
+}
+
+// TestDataAPITimestampNow verifies DataAPITimestampNow produces a current-ish timestamp.
+func TestDataAPITimestampNow(t *testing.T) {
+	before := time.Now()
+	ts := DataAPITimestampNow()
+	after := time.Now()
+
+	if ts.Time().Before(before) || ts.Time().After(after) {
+		t.Errorf("DataAPITimestampNow() = %v, expected between %v and %v", ts.Time(), before, after)
+	}
+}
+
+// TestDataAPITimestampIsZero verifies IsZero behavior.
+func TestDataAPITimestampIsZero(t *testing.T) {
+	var zero DataAPITimestamp
+	if !zero.IsZero() {
+		t.Error("expected zero DataAPITimestamp to be zero")
+	}
+	ts := DataAPITimestampNow()
+	if ts.IsZero() {
+		t.Error("expected generated DataAPITimestamp to be non-zero")
+	}
+}
+
+// TestDataAPITimestampEquals verifies Equals compares at millisecond precision.
+func TestDataAPITimestampEquals(t *testing.T) {
+	// Same millisecond, different nanoseconds
+	t1 := NewDataAPITimestamp(time.Date(2024, 1, 1, 0, 0, 0, 123000000, time.UTC))
+	t2 := NewDataAPITimestamp(time.Date(2024, 1, 1, 0, 0, 0, 123999999, time.UTC))
+	if !t1.Equals(t2) {
+		t.Error("expected timestamps within same millisecond to be equal")
+	}
+
+	// Different milliseconds
+	t3 := NewDataAPITimestamp(time.Date(2024, 1, 1, 0, 0, 0, 124000000, time.UTC))
+	if t1.Equals(t3) {
+		t.Error("expected timestamps in different milliseconds to not be equal")
+	}
+}
+
+// TestDataAPITimestampJSONUnmarshalInvalid verifies error handling for invalid JSON.
+func TestDataAPITimestampJSONUnmarshalInvalid(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"not an object", `"not-an-object"`},
+		{"missing $date key", `{"date":1690045891000}`},
+		{"non-numeric value", `{"$date":"not-a-number"}`},
+		{"empty object", `{}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ts DataAPITimestamp
+			if err := json.Unmarshal([]byte(tt.input), &ts); err == nil {
+				t.Error("expected error but got none")
+			}
+		})
+	}
+}
+
+// TestDataAPITimestampJSONRoundTrip verifies JSON marshal/unmarshal round-trip.
+//
+// Doc reference: https://docs.datastax.com/en/astra-db-serverless/api-reference/document-id.html
+func TestDataAPITimestampJSONRoundTrip(t *testing.T) {
+	original := DataAPITimestampFromMillis(1690045891000)
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed DataAPITimestamp
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if !original.Equals(parsed) {
+		t.Errorf("round-trip mismatch: %v != %v", original, parsed)
+	}
+}
+
+// TestDataAPITimestampString verifies String returns RFC3339Nano format.
+func TestDataAPITimestampString(t *testing.T) {
+	ts := DataAPITimestampFromMillis(1690045891000)
+	s := ts.String()
+	expected := "2023-07-22T17:11:31Z"
+	if s != expected {
+		t.Errorf("\nGOT:\n%q\nWANT:\n%q", s, expected)
+	}
+}
+
+// TestDataAPITimestampNegativeEpoch verifies handling of pre-epoch timestamps.
+func TestDataAPITimestampNegativeEpoch(t *testing.T) {
+	// 1969-12-31T23:59:59Z = -1000 milliseconds
+	ts := DataAPITimestampFromMillis(-1000)
+	data, err := json.Marshal(ts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := `{"$date":-1000}`
+	if string(data) != expected {
+		t.Errorf("got %s, want %s", data, expected)
+	}
+
+	var parsed DataAPITimestamp
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if !ts.Equals(parsed) {
+		t.Errorf("round-trip mismatch for negative epoch")
+	}
+}

--- a/datatypes/timestamp_test.go
+++ b/datatypes/timestamp_test.go
@@ -132,8 +132,6 @@ func TestDataAPITimestampJSONUnmarshalInvalid(t *testing.T) {
 }
 
 // TestDataAPITimestampJSONRoundTrip verifies JSON marshal/unmarshal round-trip.
-//
-// Doc reference: https://docs.datastax.com/en/astra-db-serverless/api-reference/document-id.html
 func TestDataAPITimestampJSONRoundTrip(t *testing.T) {
 	original := DataAPITimestampFromMillis(1690045891000)
 	data, err := json.Marshal(original)


### PR DESCRIPTION
Hey @toptobes this adds Object IDs and DataAPITimestamps (aka $dates). LMK what is missing here. I read this from the python docs hence timestamp only:

> The Python client provides the DataAPITimestamp and DataAPIDate objects for storing dates. However, if you insert a document with a DataAPIDate value, the client will always return DataAPITimestamp. DataStax recommends that you use DataAPITimestamp instead of DataAPIDate for collections since equality filters on DataAPIDate may not behave as expected if the implicit conversion to DataAPITimestamp uses a different timezone than expected. The DataAPITime and DataAPIDuration objects cannot be used with collections. For more information, see [Python client usage: Client custom data types](https://docs.datastax.com/en/astra-db-serverless/api-reference/python-client.html#client-custom-data-types).

Also I'm always `json.Mashal`-ing to ms not seconds which I think is the correct behavior.