### PR TITLE
fix createCollection command name typo and collection's FindOne payload building

### DIFF
--- a/common_impls.go
+++ b/common_impls.go
@@ -248,14 +248,22 @@ type findOneOptions struct {
 }
 
 func findOne(ctx context.Context, f filter.Filterable, mkCmd mkCmd, opts findOneOptions, target serdes.Target) *results.SingleResult {
-	cmd := mkCmd("findOne", map[string]any{
-		"filter":     f,
-		"sort":       opts.Sort,
-		"projection": opts.Projection,
+	payload := map[string]any{
+		"filter": f,
 		"options": map[string]any{
 			"includeSimilarity": opts.IncludeSimilarity,
 		},
-	}, opts.APIOptions)
+	}
+
+	if opts.Sort != nil {
+		payload["sort"] = opts.Sort
+	}
+
+	if opts.Projection != nil {
+		payload["projection"] = opts.Projection
+	}
+
+	cmd := mkCmd("findOne", payload, opts.APIOptions)
 
 	b, warnings, schema, err := cmd.Execute(ctx)
 	return results.NewSingleResult(b, warnings, schema, target, err)

--- a/db.go
+++ b/db.go
@@ -131,7 +131,7 @@ func (d *Db) CreateCollection(ctx context.Context, name string, opts ...options.
 		return nil, err
 	}
 
-	cmd := d.newCmd("createTable", map[string]any{
+	cmd := d.newCmd("createCollection", map[string]any{
 		"name":    name,
 		"options": merged,
 	})

--- a/examples/collections/main.go
+++ b/examples/collections/main.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
+	"log/slog"
+	"os"
 
 	"github.com/DeanPDX/dotconfig"
 	astradb "github.com/datastax/astra-db-go"
@@ -32,6 +35,19 @@ type Book struct {
 }
 
 func main() {
+	// Parse command-line flags
+	readonly := flag.Bool("readonly", false, "Use existing collection in read-only mode instead of creating/populating/dropping a new one")
+	debug := flag.Bool("debug", false, "Verbose debug logs")
+	flag.Parse()
+
+	if *debug {
+		// Set log level to DEBUG
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+		slog.SetDefault(logger)
+	}
+
 	// Load our configuration and create a client and DB handle.
 	config, err := dotconfig.FromFileName[Config](".env")
 	if err != nil {
@@ -45,13 +61,21 @@ func main() {
 	fmt.Printf("Using database endpoint: %s\n", config.DBEndpoint)
 	ctx := context.Background()
 
-	coll := createCollection(ctx, db)
-	insertDocuments(ctx, coll)
+	var coll *astradb.Collection
+	if *readonly {
+		coll = getCollection(ctx, db)
+	} else {
+		coll = createCollection(ctx, db)
+		insertDocuments(ctx, coll)
+	}
+
 	findOneDocument(ctx, coll)
 	findAllDocuments(ctx, coll)
 	filterDocumentsByYear(ctx, coll)
 	countDocuments(ctx, coll)
-	dropCollection(ctx, db)
+	if !(*readonly) {
+		dropCollection(ctx, db)
+	}
 }
 
 func createCollection(ctx context.Context, db *astradb.Db) *astradb.Collection {
@@ -61,6 +85,13 @@ func createCollection(ctx context.Context, db *astradb.Db) *astradb.Collection {
 		log.Fatal(err)
 	}
 	fmt.Println("Created collection: my_collection")
+	return coll
+}
+
+func getCollection(ctx context.Context, db *astradb.Db) *astradb.Collection {
+	logHeader("Getting Collection")
+	coll := db.Collection("my_collection")
+	logHeader("Gotten collection")
 	return coll
 }
 


### PR DESCRIPTION
This PR fixes two collection issues observed while trying to run the example program in `examples/collections/main.go`, and adds a little handy functionality to it.

**One.** I spotted this (likely?) error which made the script fail:

```
--- Creating Collection ---
time=2026-05-12T17:14:02.462+02:00 level=DEBUG msg="Running cmd.Execute" req.url=https://b81f8dd9-1f0f-40ad-91b5-ecd28f21f803-us-east-2.apps.astra.datastax.com/api/json/v1/default_keyspace req.body="{\"createTable\":{\"name\":\"my_collection\",\"options\":{}}}"
time=2026-05-12T17:14:02.907+02:00 level=DEBUG msg="cmd.Execute response" resp.StatusCode=200 resp.Status="200 OK" resp.body="{\"errors\":[{\"id\":\"c98c69dd-8fdf-4a3b-8bb8-7b07d1635877\",\"family\":\"REQUEST\",\"scope\":\"\",\"errorCode\":\"COMMAND_FIELD_VALUE_INVALID\",\"title\":\"Command field value invalid\",\"message\":\"Command field 'command.definition' value `null` not valid: must not be null.\\n\\nResend command with valid value.\"}]}"
time=2026-05-12T17:14:02.908+02:00 level=INFO msg="Command field 'command.definition' value `null` not valid: must not be null.\n\nResend command with valid value. (code: COMMAND_FIELD_VALUE_INVALID, family: REQUEST)"
exit status 1
```

**Two.** Progressing in running that example, I notice that the FindOne payoad serializes too many explicit nulls:

```
FIND (faulty)
time=2026-05-12T17:35:19.975+02:00 level=DEBUG msg="Running cmd.Execute" req.url=https://b81f8dd9-1f0f-40ad-91b5-ecd28f21f803-us-east-2.apps.astra.datastax.com/api/json/v1/default_keyspace/my_collection req.body="{\"findOne\":{\"filter\":{\"title\":\"The Go Programming Language\"},\"options\":{\"includeSimilarity\":null},\"projection\":null,\"sort\":null}}"
time=2026-05-12T17:35:20.657+02:00 level=DEBUG msg="cmd.Execute response" resp.StatusCode=200 resp.Status="200 OK" resp.body="{\"errors\":[{\"id\":\"9dd6b7de-e927-44a1-beda-0f54177d3193\",\"family\":\"REQUEST\",\"scope\":\"PROJECTION\",\"errorCode\":\"UNSUPPORTED_PROJECTION_DEFINITION\",\"title\":\"Unsupported projection definition\",\"message\":\"Unsupported projection definition JSON value: must be Object, was Null.\\n\\nResend the command with valid projection definition.\"}]}"
time=2026-05-12T17:35:20.657+02:00 level=INFO msg="Unsupported projection definition JSON value: must be Object, was Null.\n\nResend the command with valid projection definition. (code: UNSUPPORTED_PROJECTION_DEFINITION, family: REQUEST, scope: PROJECTION)"
exit status 1
```

**Three.** Out of convenience, I added command-line options `--readonly` and `--debug` to speed up me trying to run the example.