### PR TITLE
Get sort vector fix - DRAFT

### DIFF
--- a/astra/cursors/abstract_cursor.go
+++ b/astra/cursors/abstract_cursor.go
@@ -319,12 +319,20 @@ func (c *abstractCursorImpl[Raw]) Next(ctx context.Context) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.buffered() > 0 {
+	// Only consume an item if we're already positioned at one (cursor has started)
+	// On the first call (CursorStateIdle), we don't consume anything
+	if c.state == CursorStateStarted && c.buffered() > 0 {
 		*c.acs.buffer() = (*c.acs.buffer())[1:]
 	}
 
 	if c.buffered() == 0 {
 		return c.fetchIfEmpty(ctx)
+	}
+
+	// If we have items and cursor was idle, transition to started
+	// (this handles the case where GetSortVector pre-fetched the first page)
+	if c.state == CursorStateIdle {
+		c.state = CursorStateStarted
 	}
 
 	return true

--- a/astra/cursors/find_cursor.go
+++ b/astra/cursors/find_cursor.go
@@ -83,10 +83,14 @@ func newFindCursorImpl(source findLikeCursorSource[json.RawMessage], fetcher fin
 
 // mapPage implements findLikeCursorSource.mapPage
 func (c *findCursorImpl) mapPage(resp *findResponse, targetCtx serdes.TargetDecodeCtx) *findLikePage[json.RawMessage] {
+	var sortVector *datatypes.Vector
+	if resp.Status != nil {
+		sortVector = resp.Status.SortVector
+	}
 	return &findLikePage[json.RawMessage]{
 		NextPageState: resp.Data.NextPageState,
 		Results:       resp.Data.Documents,
-		SortVector:    resp.Data.SortVector,
+		SortVector:    sortVector,
 		targetCtx:     targetCtx,
 	}
 }

--- a/astra/cursors/find_like_cursor.go
+++ b/astra/cursors/find_like_cursor.go
@@ -110,9 +110,9 @@ type findResponse struct {
 	Data struct {
 		Documents     []json.RawMessage `json:"documents"`
 		NextPageState *string           `json:"nextPageState"`
-		SortVector    *datatypes.Vector `json:"sortVector,omitempty"`
 	} `json:"data"`
 	Status *struct {
+		SortVector        *datatypes.Vector `json:"sortVector,omitempty"`
 		DocumentResponses []struct {
 			Scores map[string]float32 `json:"scores"`
 		} `json:"documentResponses"`

--- a/astra/cursors/find_like_cursor.go
+++ b/astra/cursors/find_like_cursor.go
@@ -55,6 +55,7 @@ type findLikeCursorImpl[Raw any] struct {
 	fcs         findLikeCursorSource[Raw]
 	currentPage *findLikePage[Raw]
 	initialPage *findLikePage[Raw]
+	sortVector  *datatypes.Vector // Cached sort vector, preserved even when cursor is closed
 	warnings    results.Warnings
 	fetcher     findLikeCursorFetcher
 	target      serdes.Target
@@ -84,13 +85,29 @@ func (c *findLikeCursorImpl[Raw]) GetSortVector(ctx context.Context) *datatypes.
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	// If we already have the sort vector cached, return it
+	if c.sortVector != nil {
+		return c.sortVector
+	}
+
+	// If cursor hasn't started yet and sort vector is requested, fetch the first page
+	// but keep the cursor in idle state so Next() doesn't skip the first item
 	if c.state == CursorStateIdle && c.fcs.includeSortVector() {
-		c.fetchIfEmpty(ctx)
+		c.nextPage, c.err = c.acs.fetchNextPage(ctx)
+		if c.err != nil {
+			c.state = CursorStateClosed
+			c.nextPage = false
+		}
+		// Note: we intentionally do NOT change state to CursorStateStarted here
+		// so that the first Next() call will not consume the first item
 	}
-	if c.currentPage == nil {
-		return nil
+	
+	// Cache the sort vector from current page if available
+	if c.currentPage != nil && c.currentPage.SortVector != nil {
+		c.sortVector = c.currentPage.SortVector
 	}
-	return c.currentPage.SortVector
+	
+	return c.sortVector
 }
 
 func (c *findLikeCursorImpl[Raw]) Warnings() results.Warnings {
@@ -140,6 +157,11 @@ func (c *findLikeCursorImpl[Raw]) fetchNextPage(ctx context.Context) (bool, erro
 	}
 
 	c.currentPage = c.fcs.mapPage(&resp, schema)
+	
+	// Cache the sort vector from the first page
+	if c.sortVector == nil && c.currentPage.SortVector != nil {
+		c.sortVector = c.currentPage.SortVector
+	}
 
 	return c.currentPage.NextPageState != nil, nil
 }
@@ -150,9 +172,11 @@ func (c *findLikeCursorImpl[Raw]) decode(raw Raw, result any) error {
 
 func (c *findLikeCursorImpl[Raw]) rewind() {
 	c.currentPage = c.initialPage
+	c.sortVector = nil
 	c.warnings = nil
 }
 
 func (c *findLikeCursorImpl[Raw]) close() {
 	c.currentPage = nil
+	// Note: sortVector is NOT cleared on close, so it remains accessible
 }

--- a/astra/cursors/find_like_cursor.go
+++ b/astra/cursors/find_like_cursor.go
@@ -101,12 +101,12 @@ func (c *findLikeCursorImpl[Raw]) GetSortVector(ctx context.Context) *datatypes.
 		// Note: we intentionally do NOT change state to CursorStateStarted here
 		// so that the first Next() call will not consume the first item
 	}
-	
+
 	// Cache the sort vector from current page if available
 	if c.currentPage != nil && c.currentPage.SortVector != nil {
 		c.sortVector = c.currentPage.SortVector
 	}
-	
+
 	return c.sortVector
 }
 
@@ -157,7 +157,7 @@ func (c *findLikeCursorImpl[Raw]) fetchNextPage(ctx context.Context) (bool, erro
 	}
 
 	c.currentPage = c.fcs.mapPage(&resp, schema)
-	
+
 	// Cache the sort vector from the first page
 	if c.sortVector == nil && c.currentPage.SortVector != nil {
 		c.sortVector = c.currentPage.SortVector

--- a/astra/cursors/rerank_cursor.go
+++ b/astra/cursors/rerank_cursor.go
@@ -113,10 +113,14 @@ func (c *findAndRerankCursorImpl) mapPage(resp *findResponse, targetCtx serdes.T
 		}
 	}
 
+	var sortVector *datatypes.Vector
+	if resp.Status != nil {
+		sortVector = resp.Status.SortVector
+	}
 	return &findLikePage[rawRerankedResult]{
 		NextPageState: resp.Data.NextPageState,
 		Results:       res,
-		SortVector:    resp.Data.SortVector,
+		SortVector:    sortVector,
 		targetCtx:     targetCtx,
 	}
 }

--- a/astra/cursors/rerank_cursor_test.go
+++ b/astra/cursors/rerank_cursor_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/datastax/astra-db-go/v2/astra/datatypes"
 	"github.com/datastax/astra-db-go/v2/astra/options"
 	"github.com/datastax/astra-db-go/v2/astra/serdes"
 )
@@ -30,6 +31,7 @@ func TestFindAndRerankCursorImpl_MapPage(t *testing.T) {
 		json.RawMessage(`{"_id": "2"}`),
 	}
 	resp.Status = &struct {
+		SortVector        *datatypes.Vector `json:"sortVector,omitempty"`
 		DocumentResponses []struct {
 			Scores map[string]float32 `json:"scores"`
 		} `json:"documentResponses"`

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/datastax/astra-db-go/v2
 
 go 1.24.0
 
+replace github.com/datastax/astra-db-go/v2 => ./
+
 // test deps
 require (
 	github.com/DeanPDX/dotconfig v1.0.2


### PR DESCRIPTION
This PR attempts to fix the missing result in GetSortVector for collections (and presumably table) finds.

As highlighted by working on `astra-vector-docs/modules/api-reference/examples/collections-find-many-sort-vector/example.go`, the GetSortVector prints `<nil>` even though the response gives the sort vector. The reason is that the Go client looks for it under `data.sortVector` in the response, but it should look for it under `response.sortVector`.

This is a Bob-aided attempt at fixing it. Now a simple script similar in spirit to the docs-example script returns indeed the sort vector, but in this form (not sure if it is the desired wrapping):

```
&{[-0.06364043 -0.026595363 ... 0.015331947]  false}
```

Here is a(n abridged) example response from the API:

```
{
    "data": {
        "documents": [
            {
                "_id": "028cc6a3-2b28-486f-8cc6-a32b28e86f29"
            }
        ],
        "nextPageState": null
    },
    "status": {
        "sortVector": [
            -0.06364043,
            ...,
            0.015331947
        ]
    }
}
```

And here is the silly script that incarnates the docs-example as a full runnable similar to the other `/examples` here: ([attachment).

[getsortvectorer.go.txt](https://github.com/user-attachments/files/28951252/getsortvectorer.go.txt)

_Note_ the go.mod/go.sum changes were by Bob helping me run the test script with the changed local code (it seems the v2 otherwise gets in the way and insists on using the codebase from github).