### PR TITLE
Expose NextPageState in Find cursor

### DIFF
--- a/astra/cursors/find_cursor.go
+++ b/astra/cursors/find_cursor.go
@@ -67,6 +67,17 @@ type FindCursor interface {
 	//    // handle warnings
 	//  }
 	Warnings() results.Warnings
+	// NextPageState returns the page state for the next page of results, if available.
+	//
+	// This method returns the pagination token that can be used to resume iteration
+	// from the current position. It returns `nil` if there are no more pages available
+	// or if the cursor has not yet started iteration.
+	//
+	//  pageState := cursor.NextPageState()
+	//  if pageState != nil {
+	//    // save page state for later resumption
+	//  }
+	NextPageState() *string
 }
 
 // findCursorImpl provides the base implementation for find-like operations

--- a/astra/cursors/find_like_cursor.go
+++ b/astra/cursors/find_like_cursor.go
@@ -99,6 +99,15 @@ func (c *findLikeCursorImpl[Raw]) Warnings() results.Warnings {
 	return c.warnings
 }
 
+func (c *findLikeCursorImpl[Raw]) NextPageState() *string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.currentPage == nil {
+		return nil
+	}
+	return c.currentPage.NextPageState
+}
+
 func (c *findLikeCursorImpl[Raw]) buffer() *[]Raw {
 	if c.currentPage == nil {
 		return &[]Raw{}


### PR DESCRIPTION
**By Bob; please review**
Adds a way to get NextPageState from the Find cursor for manual pagination.