### PR TITLE
AlterType, fix payload serialization

### DIFF
--- a/astra/db.go
+++ b/astra/db.go
@@ -293,8 +293,15 @@ func (d *Db) CreateType(ctx context.Context, name string, definition table.UDTDe
 
 // alterTypePayload is the payload for the alterType command.
 type alterTypePayload struct {
-	Name      string                   `json:"name"`
-	Operation table.AlterTypeOperation `json:"operation"`
+	Name string
+	Op   table.AlterTypeOperation
+}
+
+func (p alterTypePayload) MarshalAstra(_ serdes.EncodeCtx) (any, error) {
+	return map[string]any{
+		"name":       p.Name,
+		p.Op.OpKey(): p.Op,
+	}, nil
 }
 
 // AlterType alters an existing user-defined type (UDT) in the database.
@@ -313,8 +320,8 @@ func (d *Db) AlterType(ctx context.Context, name string, op table.AlterTypeOpera
 	}
 
 	cmd := d.newCmd("alterType", alterTypePayload{
-		Name:      name,
-		Operation: op,
+		Name: name,
+		Op:   op,
 	}, merged.APIOptions)
 
 	_, _, _, err = cmd.Execute(ctx)

--- a/astra/db_test.go
+++ b/astra/db_test.go
@@ -337,7 +337,7 @@ func TestAlterTypeCommandMarshal(t *testing.T) {
 	t.Run("add fields", func(t *testing.T) {
 		cmd := command.NewDataAPICommand("", "", "alterType", alterTypePayload{
 			Name: "address",
-			Operation: table.AddTypeFields{
+			Op: table.AddTypeFields{
 				Fields: table.Columns{
 					{Name: "country", Column: table.Text()},
 					{Name: "zip_code", Column: table.Int()},
@@ -350,7 +350,7 @@ func TestAlterTypeCommandMarshal(t *testing.T) {
 			t.Fatalf("failed to serialize: %v", err)
 		}
 
-		expected := `{"alterType":{"name":"address","operation":{"add":{"fields":{"country":{"type":"text"},"zip_code":{"type":"int"}}}}}}`
+		expected := `{"alterType":{"add":{"fields":{"country":{"type":"text"},"zip_code":{"type":"int"}}},"name":"address"}}`
 		if string(got) != expected {
 			t.Errorf("expected %s, got %s", expected, string(got))
 		}
@@ -359,7 +359,7 @@ func TestAlterTypeCommandMarshal(t *testing.T) {
 	t.Run("rename fields", func(t *testing.T) {
 		cmd := command.NewDataAPICommand("", "", "alterType", alterTypePayload{
 			Name: "address",
-			Operation: table.RenameTypeFields{
+			Op: table.RenameTypeFields{
 				Fields: map[string]string{
 					"street": "street_address",
 				},
@@ -371,7 +371,7 @@ func TestAlterTypeCommandMarshal(t *testing.T) {
 			t.Fatalf("failed to serialize: %v", err)
 		}
 
-		expected := `{"alterType":{"name":"address","operation":{"rename":{"fields":{"street":"street_address"}}}}}`
+		expected := `{"alterType":{"name":"address","rename":{"fields":{"street":"street_address"}}}}`
 		if string(got) != expected {
 			t.Errorf("expected %s, got %s", expected, string(got))
 		}

--- a/astra/table/definition.go
+++ b/astra/table/definition.go
@@ -549,7 +549,8 @@ type RerankService struct {
 // AlterTypeOperation represents an operation to alter a user-defined type (UDT).
 type AlterTypeOperation interface {
 	isAlterTypeOp()
-	serdes.AstraRawMarshaler
+	// OpKey returns the JSON key used for this operation (e.g. "add", "rename").
+	OpKey() string
 }
 
 // AddTypeFields is the payload for the alterType "add" operation.
@@ -558,11 +559,7 @@ type AddTypeFields struct {
 }
 
 func (a AddTypeFields) isAlterTypeOp() {}
-
-func (a AddTypeFields) MarshalAstraRaw(ctx serdes.EncodeCtx, dst []byte) ([]byte, error) {
-	type alias AddTypeFields
-	return serdes.SerializeInto(map[string]any{"add": alias(a)}, ctx.Target, dst, ctx.Flags)
-}
+func (a AddTypeFields) OpKey() string  { return "add" }
 
 // RenameTypeFields is the payload for the alterType "rename" operation.
 type RenameTypeFields struct {
@@ -570,8 +567,4 @@ type RenameTypeFields struct {
 }
 
 func (r RenameTypeFields) isAlterTypeOp() {}
-
-func (r RenameTypeFields) MarshalAstraRaw(ctx serdes.EncodeCtx, dst []byte) ([]byte, error) {
-	type alias RenameTypeFields
-	return serdes.SerializeInto(map[string]any{"rename": alias(r)}, ctx.Target, dst, ctx.Flags)
-}
+func (r RenameTypeFields) OpKey() string  { return "rename" }


### PR DESCRIPTION
This PR changes the resulting serialization for AlterTypePayload as follows: the `operation` layer is removed (the Data API does not expect it).

So instead of having e.g.

```
{
    "alterType": {
        "name": "member",
        "operation": {
            "add": {
                "fields": {
                    "email": {
                        "type": "text"
                    },
                    "credits": {
                        "type": "int"
                    }
                }
            }
        }
    }
}
```

we now end up with the working json:

```
{
    "alterType": {
        "name": "member",
        "add": {
            "fields": {
                "email": {
                    "type": "text"
                },
                "credits": {
                    "type": "int"
                }
            }
        }
    }
}
```

To achieve this, some of the logic around marshaling of the AlterTypePayload are applied (including the introduction of a "key name" string method to the alter type operation interface for building the appropriate payload).

(Besides the altered unit test, this branch is tested manually by altering a type in both `add` and `rename` ways, successfully).

Reference Slack conversation: [here](https://ibm-analytics.slack.com/archives/C09J0DB1SJ1/p1783727441505579).