### PR TITLE
Revise README with updated client installation and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Update to Go 1.24 or higher. [Download it here](https://go.dev/doc/install).
 Install the client:
 
 ```
-go get github.com/datastax/gocql-astra/v2
+go get github.com/datastax/astra-db-go/v2/astra
 ```
 
 You need an Astra DB database or a Hyper-Converged Database (HCD) for the client to connect to.
@@ -66,10 +66,28 @@ func main() {
 
     // Initialize the client
     client := astra.NewClient()
+    // Example endpoint: "https://abc123ab-abc1-abc1-abc1-abc123abc123-us-east-2.apps.astra.datastax.com"
+    // Example token: "AstraCS:abc123abc123abc123abc123:abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1"
     db := client.Database("<endpoint>", options.API().SetToken("<token>"))
 
     // Create a collection
-    coll, err := db.CreateCollection(ctx, "ExampleCollection")
+    
+    coll, err := db.CreateCollection(
+        ctx,
+        "ExampleCollection",
+        options.CreateCollection().
+            UpdateVector(
+                options.Vector().
+                    SetDimension(1024).
+                    SetMetric("cosine").
+                    // Set built-in NVIDIA provider to make this example easily runnable
+                    UpdateService(
+                        options.VectorService().
+                            SetProvider("nvidia").
+                            SetModelName("nvidia/nv-embedqa-e5-v5"),
+                    ),
+            ),
+    )
     if err != nil {
         log.Fatal(err)
     }

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ func main() {
 
     // Initialize the client
     client := astra.NewClient()
-    // Example endpoint: "https://abc123ab-abc1-abc1-abc1-abc123abc123-us-east-2.apps.astra.datastax.com"
+    // Example endpoint (do NOT include `/api/json/v1/<keyspace>`): "https://abc123ab-abc1-abc1-abc1-abc123abc123-us-east-2.apps.astra.datastax.com"
     // Example token: "AstraCS:abc123abc123abc123abc123:abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1"
     db := client.Database("<endpoint>", options.API().SetToken("<token>"))
 


### PR DESCRIPTION
I tried out the Go client and it works pretty well! Just had a couple of small suggestions:

1. Current code sample doesn't work with `go get github.com/datastax/gocql-astra/v2`. It looks like `go get github.com/datastax/astra-db-go/v2/astra` is correct - can you please confirm or am I missing something?
2. I added a fake endpoint and token to the `connect()` call since I got tripped up with putting `/api/json/v1/keyspaceName` in my endpoint, and that led to an error when using a cursor.
3. Current `db.CreateCollection(ctx, "ExampleCollection")` call doesn't specify an embedding provider, which means as written the provided program will always fail with `Collection 'ExampleCollection' does not have embedding service configured: cannot vectorize data.` - not a great first user experience. I added the built-in NVIDIA provider so the user can get something up and running easily without having to configure an additional provider in the Astra console.