### PR TITLE
Update README to point to HCD 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ For Astra DB Serverless:
 
 For Hyper-Converged Database (HCD):
 
-- [Quickstart for collections](https://docs.datastax.com/en/hyper-converged-database/1.2/api-reference/quickstart.html)
-- [Quickstart for tables](https://docs.datastax.com/en/hyper-converged-database/1.2/api-reference/quickstart-tables.html)
-- [Get started with the Data API](https://docs.datastax.com/en/hyper-converged-database/1.2/api-reference/dataapiclient.html)
+- [Quickstart for collections](https://docs.datastax.com/en/hyper-converged-database/2.0/api-reference/quickstart.html)
+- [Quickstart for tables](https://docs.datastax.com/en/hyper-converged-database/2.0/api-reference/quickstart-tables.html)
+- [Get started with the Data API](https://docs.datastax.com/en/hyper-converged-database/2.0/api-reference/dataapiclient.html)
 
 Package-level documentation is available on [pkg.go.dev](https://pkg.go.dev/github.com/datastax/astra-db-go/v2).
 


### PR DESCRIPTION
Update the README to point to the HCD 2.0 docs instead of the 1.2 docs